### PR TITLE
[#179218912] Add TrackingRequest

### DIFF
--- a/lib/sendcloud.rb
+++ b/lib/sendcloud.rb
@@ -13,11 +13,12 @@ require "sendcloud/errors/bad_request_error"
 require "sendcloud/errors/deleted_error"
 
 require "sendcloud/operation"
+require "sendcloud/operations/cancel_parcel_request"
 require "sendcloud/operations/create_parcel_request"
 require "sendcloud/operations/create_shipment_request"
 require "sendcloud/operations/printer_label_request"
 require "sendcloud/operations/shipping_methods_request"
-require "sendcloud/operations/cancel_parcel_request"
+require "sendcloud/operations/tracking_request"
 
 module Sendcloud
 end

--- a/lib/sendcloud/operations/tracking_request.rb
+++ b/lib/sendcloud/operations/tracking_request.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Sendcloud
+  module Operations
+    class TrackingRequest < Operation
+      TRACKING_PARAMS = [
+        :tracking_number,
+        :tracking_url,
+        :carrier
+      ].freeze
+
+      private
+
+      def handle_response_body(body)
+        body[:parcel].slice(*TRACKING_PARAMS)
+      end
+
+      def endpoint
+        "parcels/#{options[:parcel_id]}"
+      end
+
+      def http_method
+        :get
+      end
+    end
+  end
+end

--- a/lib/sendcloud/operations/tracking_request.rb
+++ b/lib/sendcloud/operations/tracking_request.rb
@@ -6,7 +6,8 @@ module Sendcloud
       TRACKING_PARAMS = [
         :tracking_number,
         :tracking_url,
-        :carrier
+        :carrier,
+        :status
       ].freeze
 
       private

--- a/spec/sendcloud/operations/tracking_request_spec.rb
+++ b/spec/sendcloud/operations/tracking_request_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Sendcloud::Operations::TrackingRequest do
                 tracking_url: "https://tracking.sendcloud.sc/forward?carrier=postnl&code=3SYZXG193621471&destination=NL&lang=en-gb&source=NL&type=parcel&verification=5642+CV&created_at=2021-08-19",
                 carrier: {
                   code: "postnl"
+                },
+                status: {
+                  id: 2000,
+                  message: "Cancelled"
                 }
               }
             )

--- a/spec/sendcloud/operations/tracking_request_spec.rb
+++ b/spec/sendcloud/operations/tracking_request_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe Sendcloud::Operations::TrackingRequest do
+  let(:default_base_url) { "https://panel.sendcloud.sc/api/v2/" }
+
+  before { configure_client(base_url: default_base_url) }
+
+  describe "#execute" do
+    subject { described_class.new(parcel_id: parcel_id) }
+
+    context "with invalid parcel id" do
+      let(:parcel_id) { "0" }
+
+      it "raises a not found exception" do
+        VCR.use_cassette("tracking_request/invalid_parcel_id") do
+          aggregate_failures do
+            expect {
+              subject.execute
+            }.to raise_error(
+              Sendcloud::Errors::ResponseError, "404 No Parcel matches the given query."
+            )
+            expect(subject.response.status).to eq(404)
+          end
+        end
+      end
+    end
+
+    context "when parcel is valid" do
+      let(:parcel_id) { "124320972" }
+
+      it "retrieves the parcel" do
+        VCR.use_cassette("tracking_request/valid_parcel_id") do
+          result = subject.execute
+
+          aggregate_failures do
+            expect(subject.response.status).to eq(200)
+
+            expect(result).to be_instance_of(Hash)
+            expect(result).to eq(
+              {
+                tracking_number: "3SYZXG193621471",
+                tracking_url: "https://tracking.sendcloud.sc/forward?carrier=postnl&code=3SYZXG193621471&destination=NL&lang=en-gb&source=NL&type=parcel&verification=5642+CV&created_at=2021-08-19",
+                carrier: {
+                  code: "postnl"
+                }
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/sendcloud/operations/tracking_request_spec.rb
+++ b/spec/sendcloud/operations/tracking_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Sendcloud::Operations::TrackingRequest do
   describe "#execute" do
     subject { described_class.new(parcel_id: parcel_id) }
 
-    context "with invalid parcel id" do
+    context "with an invalid parcel id" do
       let(:parcel_id) { "0" }
 
       it "raises a not found exception" do
@@ -26,10 +26,10 @@ RSpec.describe Sendcloud::Operations::TrackingRequest do
       end
     end
 
-    context "when parcel is valid" do
+    context "with a valid parcel ID" do
       let(:parcel_id) { "124320972" }
 
-      it "retrieves the parcel" do
+      it "retrieves the tracking information for the parcel" do
         VCR.use_cassette("tracking_request/valid_parcel_id") do
           result = subject.execute
 

--- a/spec/support/fixtures/vcr_cassettes/tracking_request/invalid_parcel_id.yml
+++ b/spec/support/fixtures/vcr_cassettes/tracking_request/invalid_parcel_id.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://panel.sendcloud.sc/api/v2/parcels/0
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      User-Agent:
+      - Faraday v1.7.0
+      Authorization:
+      - Basic <BASIC_AUTH_CREDENTIALS>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 23 Aug 2021 10:21:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '98'
+      Connection:
+      - close
+      Server:
+      - nginx
+      Allow:
+      - GET, PUT, PATCH, HEAD, OPTIONS
+      X-Sendcloud-Client-Latest-Version-Windows:
+      - 1.0.4
+      X-Sendcloud-Client-Latest-Version-Macos:
+      - 1.0.5
+      X-Sendcloud-Client-Latest-Version-Linux:
+      - 1.0.2
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      Vary:
+      - Origin, Cookie
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":404,"request":"api/v2/parcels/0","message":"No Parcel
+        matches the given query."}}'
+  recorded_at: Mon, 23 Aug 2021 10:21:13 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/fixtures/vcr_cassettes/tracking_request/valid_parcel_id.yml
+++ b/spec/support/fixtures/vcr_cassettes/tracking_request/valid_parcel_id.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://panel.sendcloud.sc/api/v2/parcels/124320972
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      User-Agent:
+      - Faraday v1.7.0
+      Authorization:
+      - Basic <BASIC_AUTH_CREDENTIALS>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 23 Aug 2021 10:21:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      - Origin, Cookie
+      Allow:
+      - GET, PUT, PATCH, HEAD, OPTIONS
+      X-Sendcloud-Client-Latest-Version-Windows:
+      - 1.0.4
+      X-Sendcloud-Client-Latest-Version-Macos:
+      - 1.0.5
+      X-Sendcloud-Client-Latest-Version-Linux:
+      - 1.0.2
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: ASCII-8BIT
+      string: '{"parcel":{"id":124320972,"address":"Insulindelaan 115","address_2":"","address_divided":{"street":"Insulindelaan","house_number":"115"},"city":"Eindhoven","company_name":"Bloom&Wild","country":{"iso_2":"NL","iso_3":"NLD","name":"Netherlands"},"data":{},"date_created":"19-08-2021
+        15:52:16","date_announced":"19-08-2021 15:52:16","date_updated":"20-08-2021
+        03:20:35","email":"hello@bloomandwild.com","name":"John Doe","postal_code":"5642
+        CV","reference":"0","shipment":{"id":2,"name":"PostNL with signature 0-23kg"},"status":{"id":2000,"message":"Cancelled"},"to_service_point":null,"telephone":"+31612345678","tracking_number":"3SYZXG193621471","weight":"1.000","label":{"normal_printer":["https://panel.sendcloud.sc/api/v2/labels/normal_printer/124320972?start_from=0","https://panel.sendcloud.sc/api/v2/labels/normal_printer/124320972?start_from=1","https://panel.sendcloud.sc/api/v2/labels/normal_printer/124320972?start_from=2","https://panel.sendcloud.sc/api/v2/labels/normal_printer/124320972?start_from=3"],"label_printer":"https://panel.sendcloud.sc/api/v2/labels/label_printer/124320972"},"customs_declaration":{},"order_number":"1234567890","insured_value":0,"total_insured_value":0,"to_state":null,"customs_invoice_nr":"","customs_shipment_type":null,"parcel_items":[],"documents":[{"type":"label","size":"a6","link":"https://panel.sendcloud.sc/api/v2/parcels/124320972/documents/label"}],"type":"parcel","shipment_uuid":null,"shipping_method":2,"external_order_id":"124320972","external_shipment_id":"","external_reference":null,"is_return":false,"note":"","to_post_number":"","total_order_value":null,"total_order_value_currency":null,"colli_tracking_number":"3SYZXG193621471","colli_uuid":"2d170369-6d12-4111-994d-f3cbabf9527a","collo_nr":0,"collo_count":1,"awb_tracking_number":null,"box_number":null,"length":null,"width":null,"height":null,"shipping_method_checkout_name":"DHL
+        Express Domestic","carrier":{"code":"postnl"},"tracking_url":"https://tracking.sendcloud.sc/forward?carrier=postnl&code=3SYZXG193621471&destination=NL&lang=en-gb&source=NL&type=parcel&verification=5642+CV&created_at=2021-08-19"}}'
+  recorded_at: Mon, 23 Aug 2021 10:21:13 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
This PR adds `TrackingRequest` which requests a parcel by ID, retrieves the API repsonse, and pulls out the following tracking information:

* Tracking code
* Tracking URL
* Carrier code
* Status

This was verified in the console:

```ruby
Sendcloud::Operations::TrackingRequest.new(parcel_id: 124320972).execute

{
  :tracking_number => "3SYZXG193621471",
  :tracking_url => "https://tracking.sendcloud.sc/forward?carrier=postnl&code=3SYZXG193621471&destination=NL&lang=en-gb&source=NL&type=parcel&verification=5642+CV&created_at=2021-08-19",
  :carrier => {
    :code => "postnl"
  },
  :status => {
    :id => 2000,
    :message => "Cancelled"
  }
}
```