### PR TITLE
Add date_updated to tracking response

### DIFF
--- a/lib/sendcloud/operations/tracking_request.rb
+++ b/lib/sendcloud/operations/tracking_request.rb
@@ -7,7 +7,8 @@ module Sendcloud
         :tracking_number,
         :tracking_url,
         :carrier,
-        :status
+        :status,
+        :date_updated
       ].freeze
 
       private

--- a/spec/sendcloud/operations/tracking_request_spec.rb
+++ b/spec/sendcloud/operations/tracking_request_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Sendcloud::Operations::TrackingRequest do
                 status: {
                   id: 2000,
                   message: "Cancelled"
-                }
+                },
+                date_updated: "20-08-2021 03:20:35"
               }
             )
           end


### PR DESCRIPTION
This PR adds `date_updated` from the main parcel API response to the `TrackingRequest`.