### PR TITLE
[#LR-610] Add sender addresses request operation

### DIFF
--- a/lib/sendcloud.rb
+++ b/lib/sendcloud.rb
@@ -18,6 +18,7 @@ require "sendcloud/operations/create_parcel_request"
 require "sendcloud/operations/create_shipment_request"
 require "sendcloud/operations/parcels_request"
 require "sendcloud/operations/printer_label_request"
+require "sendcloud/operations/sender_addresses_request"
 require "sendcloud/operations/shipping_methods_request"
 require "sendcloud/operations/tracking_request"
 

--- a/lib/sendcloud/operations/sender_addresses_request.rb
+++ b/lib/sendcloud/operations/sender_addresses_request.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Sendcloud
+  module Operations
+    class SenderAddressesRequest < Operation
+      private
+
+      def handle_response_body(body)
+        body[:sender_addresses]
+      end
+
+      def endpoint
+        "user/addresses/sender"
+      end
+
+      def http_method
+        :get
+      end
+    end
+  end
+end

--- a/spec/sendcloud/operations/sender_addresses_request_spec.rb
+++ b/spec/sendcloud/operations/sender_addresses_request_spec.rb
@@ -12,24 +12,21 @@ RSpec.describe Sendcloud::Operations::SenderAddressesRequest do
   describe "#execute" do
     let(:subject) { described_class.new }
 
-    it "returns a response in the expected format" do
+    it "returns a response in the expected format", :aggregate_failures do
       VCR.use_cassette("sender_addresses_request/valid_request") do
         result = subject.execute
 
-        aggregate_failures do
-          expect(subject.response.status).to eq(200)
-          expect(result).to be_instance_of(Array)
-          expect(result.first.keys).to include(:id, :label)
+        expect(subject.response.status).to eq(200)
+        expect(result).to be_instance_of(Array)
 
-          expect(result.find { |sender_address| sender_address[:label] == "Innovation Centre" }).to match(
-            hash_including(
-              {
-                label: "Innovation Centre",
-                id: 393806
-              }
-            )
+        expect(result.find { |sender_address| sender_address[:label] == "Innovation Centre" }).to match(
+          hash_including(
+            {
+              label: "Innovation Centre",
+              id: 393806
+            }
           )
-        end
+        )
       end
     end
   end

--- a/spec/sendcloud/operations/sender_addresses_request_spec.rb
+++ b/spec/sendcloud/operations/sender_addresses_request_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Sendcloud::Operations::SenderAddressesRequest do
+  let(:default_base_url) { "https://panel.sendcloud.sc/api/v2/" }
+
+  before do
+    configure_client(base_url: default_base_url)
+  end
+
+  describe "#execute" do
+    let(:subject) { described_class.new }
+
+    it "returns a response in the expected format" do
+      VCR.use_cassette("sender_addresses_request/valid_request") do
+        result = subject.execute
+
+        aggregate_failures do
+          expect(subject.response.status).to eq(200)
+          expect(result).to be_instance_of(Array)
+          expect(result.first.keys).to include(:id, :label)
+
+          expect(result.find { |sender_address| sender_address[:label] == "Innovation Centre" }).to match(
+            hash_including(
+              {
+                label: "Innovation Centre",
+                id: 393806
+              }
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/sender_addresses_request/valid_request.yml
+++ b/spec/support/fixtures/vcr_cassettes/sender_addresses_request/valid_request.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://panel.sendcloud.sc/api/v2/user/addresses/sender
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      User-Agent:
+      - Faraday v1.10.2
+      Authorization:
+      - Basic <BASIC_AUTH_CREDENTIALS>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - envoy
+      Date:
+      - Tue, 14 Feb 2023 11:02:11 GMT
+      Content-Type:
+      - application/json
+      Allow:
+      - GET, HEAD, OPTIONS
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - same-origin
+      X-Frame-Options:
+      - DENY
+      Vary:
+      - Origin, Cookie
+      Content-Length:
+      - '1651'
+      X-Envoy-Upstream-Service-Time:
+      - '80'
+    body:
+      encoding: UTF-8
+      string: '{"sender_addresses":[{"id":129444,"company_name":"Bloomon UK","contact_name":"Lars
+        Ackerman","email":"lars.ackerman@bloomon.nl","telephone":"+31625012179","street":"Hotton
+        Garden","house_number":"34-35","postal_box":"","postal_code":"EC1N 8DX","city":"London","country":"GB","country_state":null,"vat_number":null,"eori_number":"GBASDFSADF","label":"","brand_id":82742,"signature_full_name":"","signature_initials":""},{"id":96644,"company_name":"Bloomon
+        test DE","contact_name":"Lars Ackerman","email":"max.shytikov+test@bloomon.com","telephone":"+31625012179","street":"Debyestrasse","house_number":"555","postal_box":"","postal_code":"52078","city":"Aachen","country":"DE","country_state":null,"vat_number":null,"eori_number":null,"label":"","brand_id":82742,"signature_full_name":"","signature_initials":""},{"id":93780,"company_name":"Bloomon
+        Test NL","contact_name":"Bloomon","email":"patrick.hurenkamp+test@bloomon.com","telephone":"+31646447049","street":"Legmeerdijk","house_number":"313","postal_box":"B.006-54","postal_code":"1431
+        GB","city":"Aalsmeer","country":"NL","country_state":null,"vat_number":null,"eori_number":null,"label":"","brand_id":82742,"signature_full_name":"","signature_initials":""},{"id":393806,"company_name":"Bloom
+        & Wild Ltd","contact_name":".","email":"lars.ackerman@bloomon.nl","telephone":"+31858884404","street":"Bermuda
+        Industrial Estate","house_number":"2","postal_box":"Gresham Road, St Georges
+        Way","postal_code":"CV10 7QR","city":"Nuneaton","country":"GB","country_state":null,"vat_number":"","eori_number":"","label":"Innovation
+        Centre","brand_id":82742,"signature_full_name":"","signature_initials":""}]}'
+  recorded_at: Tue, 14 Feb 2023 11:02:09 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
https://bloomon.atlassian.net/browse/LR-610

Why

As a customer
I want Bloom & Wild to have the ability to ship via Amazon Shipping
So that there is more chance of my delivery arriving on time on Royal Mail strike days

Acceptance Criteria

Scenario: Booking for Sendcloud with UIC supplier
Given a delivery for Sendcloud Amazon UK from the UIC
When the delivery is booked with Sendcloud
Then we specify the UIC address as the sender address

Scenario: Booking for Sendcloud with Finlays supplier
Given a delivery for Sendcloud Amazon UK from Finlays
When the delivery is booked with Sendcloud
Then we specify the Finlays address as the sender address

Scenario: Booking for Sendcloud with Butters supplier
Given a delivery for Sendcloud Amazon UK from Butters
When the delivery is booked with Sendcloud
Then we specify the Butters address as the sender address

Scenario: Booking for Sendcloud with a different supplier
Given a delivery for Sendcloud Amazon UK from a different supplier
When the delivery is booked with Sendcloud
Then we don't specify and sender ID in the booking request
And the label is created using the Sendcloud account default sender address

Notes:

We currently have the UIC address configured as the default address on both staging and production Sendcloud UK accounts for the initial trial launch.

Going forwards we need to switch based on supplier configured in admin (finlays, butters, or Innovation Centre)

Implementation notes:

Sender addresses within Sendcloud need to be preconfigured via the [Sender Addresses](https://app.sendcloud.com/v2/settings/addresses/sender) tab (double check with Gabby on the exact address fields to use for each supplier)

We then have to query the [addresses API](https://api.sendcloud.dev/docs/sendcloud-public-api/sender-addresses/operations/get-a-user-address-sender) to request the sender addresses, filter to the one we want (e.g. by supplier postcode?), take the sender address ID, and then specify that sender ID as part of the create parcel request

We will need to cache the addresses response, we can follow the same pattern that we use for the shipping methods request

Testing ideas:

Book a delivery with each of the suppliers listed above, ensure that the resulting Amazon Shipping label has the correct sender address

Book a delivery with a different supplier, ensure that we don’t specify a sender ID and there are no errors