### PR TITLE
Send an empty request body when no payload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sendcloud (0.5.0)
+    sendcloud (0.6.0)
       faraday (> 1.0, < 2.0)
 
 GEM

--- a/lib/sendcloud/operation.rb
+++ b/lib/sendcloud/operation.rb
@@ -6,16 +6,15 @@ module Sendcloud
       content_type: "application/json"
     }.freeze
 
-    attr_reader :response, :options
+    attr_reader :response, :options, :http_client
 
     def initialize(**options)
       @options = options
+      @http_client = Faraday.new
+      http_client.basic_auth(public_key, secret_key)
     end
 
     def execute
-      http_client = Faraday.new
-      http_client.basic_auth(public_key, secret_key)
-
       json_payload = payload ? JSON.generate(payload) : nil
       @response = http_client.run_request(http_method, api_url, json_payload, headers)
       body = JSON.parse(response.body, symbolize_names: true)

--- a/lib/sendcloud/operation.rb
+++ b/lib/sendcloud/operation.rb
@@ -16,7 +16,7 @@ module Sendcloud
       http_client = Faraday.new
       http_client.basic_auth(public_key, secret_key)
 
-      json_payload = JSON.generate(payload)
+      json_payload = payload ? JSON.generate(payload) : nil
       @response = http_client.run_request(http_method, api_url, json_payload, headers)
       body = JSON.parse(response.body, symbolize_names: true)
       return handle_response_body(body) if response.success?

--- a/lib/sendcloud/version.rb
+++ b/lib/sendcloud/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sendcloud
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/sendcloud/operation_spec.rb
+++ b/spec/sendcloud/operation_spec.rb
@@ -75,4 +75,29 @@ RSpec.describe Sendcloud::Operation do
       end
     end
   end
+
+  context "with payload" do
+    before do
+      # public_key and secret_key passed as arguments take precedence over the global config
+      configure_client(base_url: default_base_url, public_key: "broken", secret_key: "wrong")
+    end
+
+    it "sends a request with empty body" do
+      operation = default_class.new(
+        public_key: ENV.fetch("SENDCLOUD_PUBLIC_KEY", ""),
+        secret_key: ENV.fetch("SENDCLOUD_SECRET_KEY", "")
+      )
+      expect_any_instance_of(Faraday)
+        .to receive(:run_request)
+        .with(
+          :get,
+          "https://panel.sendcloud.sc/api/v2/parcels/statuses",
+          "null",
+          {content_type: "application/json"},
+        )
+        .and_return("{}")
+
+      operation.execute
+    end
+  end
 end

--- a/spec/sendcloud/operation_spec.rb
+++ b/spec/sendcloud/operation_spec.rb
@@ -83,21 +83,23 @@ RSpec.describe Sendcloud::Operation do
     end
 
     it "sends a request with empty body" do
-      operation = default_class.new(
-        public_key: ENV.fetch("SENDCLOUD_PUBLIC_KEY", ""),
-        secret_key: ENV.fetch("SENDCLOUD_SECRET_KEY", "")
-      )
-      expect_any_instance_of(Faraday)
-        .to receive(:run_request)
-        .with(
-          :get,
-          "https://panel.sendcloud.sc/api/v2/parcels/statuses",
-          "null",
-          {content_type: "application/json"},
+      VCR.use_cassette("operation/request_body") do
+        operation = default_class.new(
+          public_key: ENV.fetch("SENDCLOUD_PUBLIC_KEY", ""),
+          secret_key: ENV.fetch("SENDCLOUD_SECRET_KEY", "")
         )
-        .and_return("{}")
+        expect(operation.http_client)
+          .to receive(:run_request)
+          .with(
+            :get,
+            "https://panel.sendcloud.sc/api/v2/parcels/statuses",
+            nil,
+            {content_type: "application/json"},
+          )
+          .and_call_original
 
-      operation.execute
+        operation.execute
+      end
     end
   end
 end

--- a/spec/sendcloud/operation_spec.rb
+++ b/spec/sendcloud/operation_spec.rb
@@ -76,18 +76,20 @@ RSpec.describe Sendcloud::Operation do
     end
   end
 
-  context "with payload" do
+  context "without payload" do
     before do
       # public_key and secret_key passed as arguments take precedence over the global config
       configure_client(base_url: default_base_url, public_key: "broken", secret_key: "wrong")
     end
 
-    it "sends a request with empty body" do
+    it "sends a request with an empty body" do
       VCR.use_cassette("operation/request_body") do
         operation = default_class.new(
           public_key: ENV.fetch("SENDCLOUD_PUBLIC_KEY", ""),
           secret_key: ENV.fetch("SENDCLOUD_SECRET_KEY", "")
         )
+
+        # NOTE: The main expectation is on the request's body
         expect(operation.http_client)
           .to receive(:run_request)
           .with(

--- a/spec/support/fixtures/vcr_cassettes/operation/request_body.yml
+++ b/spec/support/fixtures/vcr_cassettes/operation/request_body.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://panel.sendcloud.sc/api/v2/parcels/statuses
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.2
+      Authorization:
+      - Basic <BASIC_AUTH_CREDENTIALS>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - envoy
+      Date:
+      - Tue, 09 Jan 2024 17:38:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Allow:
+      - GET, HEAD, OPTIONS
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      X-Frame-Options:
+      - DENY
+      Vary:
+      - Origin, Cookie
+      Content-Length:
+      - '1509'
+      X-Envoy-Upstream-Service-Time:
+      - '81'
+    body:
+      encoding: UTF-8
+      string: '[{"id":6,"message":"Not sorted"},{"id":15,"message":"Error collecting"},{"id":94,"message":"Parcel
+        cancellation failed."},{"id":1999,"message":"Cancellation requested"},{"id":62996,"message":"Exception"},{"id":62989,"message":"At
+        Customs"},{"id":62993,"message":"Delivery method changed"},{"id":62990,"message":"At
+        sorting centre"},{"id":1998,"message":"Cancelled upstream"},{"id":1002,"message":"Announcement
+        failed"},{"id":62991,"message":"Refused by recipient"},{"id":62992,"message":"Returned
+        to sender"},{"id":62995,"message":"Delivery address changed"},{"id":2001,"message":"Submitting
+        cancellation request"},{"id":92,"message":"Driver en route"},{"id":62994,"message":"Delivery
+        date changed"},{"id":62997,"message":"Address invalid"},{"id":12,"message":"Awaiting
+        customer pickup"},{"id":11,"message":"Delivered"},{"id":93,"message":"Shipment
+        collected by customer"},{"id":91,"message":"Parcel en route"},{"id":80,"message":"Unable
+        to deliver"},{"id":22,"message":"Shipment picked up by driver"},{"id":13,"message":"Announced:
+        not collected"},{"id":8,"message":"Delivery attempt failed"},{"id":7,"message":"Being
+        sorted"},{"id":5,"message":"Sorted"},{"id":4,"message":"Delivery delayed"},{"id":3,"message":"En
+        route to sorting center"},{"id":1,"message":"Announced"},{"id":1337,"message":"Unknown
+        status - check carrier track & trace page for more insights"},{"id":999,"message":"No
+        label"},{"id":1001,"message":"Being announced"},{"id":2000,"message":"Cancelled"},{"id":1000,"message":"Ready
+        to send"}]'
+  recorded_at: Tue, 09 Jan 2024 17:38:12 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
https://bloomandwild.slack.com/archives/C834ZN72L/p1704812548388129

Previously the gem sent a malformed HTTP request:

```ruby
http_client.run_request(:get, "https://panel.sendcloud.sc/api/v2/shipping_methods", "null", {:content_type=>"application/json"})
```

Note the `"null"` payload.

```ruby
http_client.run_request(:get, "https://panel.sendcloud.sc/api/v2/shipping_methods", "", {:content_type=>"application/json"})
```

Sending an empty payload body returns the desired response.